### PR TITLE
Add macOS support to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeepSeek Claude CLI
 
-A CLI wrapper that creates an isolated Claude Code installation configured to use DeepSeek's Anthropic-compatible API instead of the standard Anthropic API.
+A CLI wrapper that creates an isolated Claude Code installation configured to use DeepSeek's Anthropic-compatible API instead of the standard Anthropic API. The installation script works on both macOS and Linux.
 
 ## 🚀 What This Does
 
@@ -26,8 +26,8 @@ This project provides a seamless way to use Claude Code with DeepSeek's API whil
 export DEEPSEEK_API_KEY=your_actual_api_key_here
 
 # Permanent setup (add to shell profile)
-echo 'export DEEPSEEK_API_KEY=your_actual_api_key_here' >> ~/.bashrc  # or ~/.zshrc
-source ~/.bashrc  # or source ~/.zshrc
+echo 'export DEEPSEEK_API_KEY=your_actual_api_key_here' >> ~/.bashrc  # or ~/.bash_profile / ~/.zshrc
+source ~/.bashrc  # or source ~/.bash_profile / ~/.zshrc
 ```
 
 ### 2. Run the Installation
@@ -44,10 +44,10 @@ chmod +x install-deepseek-claude.sh
 **Option B: One-line curl installation**
 ```bash
 # Install directly from GitHub
-curl -L https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh | sh
+curl -L https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh | bash
 ```
 
-**⚠️ Security Note**: Always review scripts before piping them to sh. You can download and inspect first:
+**⚠️ Security Note**: Always review scripts before piping them to bash. You can download and inspect first:
 ```bash
 curl -O https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh
 # Review the script, then run:

--- a/install-deepseek-claude.sh
+++ b/install-deepseek-claude.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # DeepSeek Claude Installation Script
 # This script installs claude-code in an isolated environment configured for DeepSeek
-# Can be run directly or via curl: curl -L https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh | sh
+# Can be run directly or via curl: curl -L https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh | bash
 
 set -e
 
@@ -19,6 +19,9 @@ BIN_DIR="/usr/local/bin"
 WRAPPER_SCRIPT="deepseek-claude"
 
 echo -e "${BLUE}🚀 Installing DeepSeek Claude in isolated environment...${NC}"
+
+# Detect operating system (Linux or macOS)
+OS="$(uname -s)"
 
 # Check if Node.js and npm are installed
 if ! command -v node &> /dev/null; then
@@ -97,9 +100,14 @@ chmod +x "$INSTALL_DIR/$WRAPPER_SCRIPT"
 echo -e "${BLUE}🔗 Adding to PATH...${NC}"
 SHELL_PROFILE=""
 if [ "$SHELL" = "/bin/zsh" ] || [ "$SHELL" = "/usr/bin/zsh" ]; then
+    # zsh uses the same profile file on macOS and Linux
     SHELL_PROFILE="$HOME/.zshrc"
 elif [ "$SHELL" = "/bin/bash" ] || [ "$SHELL" = "/usr/bin/bash" ]; then
-    SHELL_PROFILE="$HOME/.bashrc"
+    if [ "$OS" = "Darwin" ]; then
+        SHELL_PROFILE="$HOME/.bash_profile"
+    else
+        SHELL_PROFILE="$HOME/.bashrc"
+    fi
 fi
 
 if [ -n "$SHELL_PROFILE" ]; then
@@ -129,8 +137,8 @@ echo -e "${BLUE}📚 Additional Information:${NC}"
 echo -e "• Your original claude installation remains untouched"
 echo -e "• DeepSeek Claude is installed in: $INSTALL_DIR"
 echo -e "• The command 'deepseek-claude' is now available system-wide"
-echo -e "• To uninstall, simply run: rm -rf $INSTALL_DIR && sudo rm $BIN_DIR/$WRAPPER_SCRIPT"
-echo -e "• For future installations, you can use: curl -L https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh | sh"
+echo -e "• To uninstall, simply run: rm -rf $INSTALL_DIR"
+echo -e "• For future installations, you can use: curl -L https://raw.githubusercontent.com/iDrwish/deepseek-claude-wrapper/main/install-deepseek-claude.sh | bash"
 echo ""
 echo -e "${BLUE}🔧 Environment Variables Set:${NC}"
 echo -e "• ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic"

--- a/tests/profile_detection.sh
+++ b/tests/profile_detection.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_install() {
+  local os shell profile fake_home stubdir
+  os="$1"
+  shell="$2"
+  profile="$3"
+
+  fake_home="$(mktemp -d)"
+  stubdir="$(mktemp -d)"
+
+  cat > "$stubdir/uname" <<STUB
+#!/usr/bin/env bash
+echo "$os"
+STUB
+  chmod +x "$stubdir/uname"
+
+  cat > "$stubdir/npm" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$stubdir/npm"
+
+  HOME="$fake_home" PATH="$stubdir:$PATH" SHELL="$shell" DEEPSEEK_API_KEY=test bash install-deepseek-claude.sh >/dev/null 2>&1
+
+  if [ ! -f "$fake_home/$profile" ]; then
+    echo "Expected profile $profile not created"
+    return 1
+  fi
+
+  grep -q 'export PATH="\$HOME/.deepseek-claude:\$PATH"' "$fake_home/$profile"
+}
+
+run_install Darwin /bin/bash .bash_profile
+run_install Linux /bin/bash .bashrc
+run_install Linux /bin/zsh .zshrc
+
+echo "Profile detection tests passed." 


### PR DESCRIPTION
## Summary
- Detect operating system in installation script and configure shell profile for macOS or Linux
- Document macOS/Linux compatibility and update installation instructions to pipe script to bash
- Add automated test verifying shell profile selection for bash and zsh across Linux and macOS

## Testing
- `bash -n install-deepseek-claude.sh`
- `bash -n uninstall-deepseek-claude.sh`
- `tests/profile_detection.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab2170d4d8832d8cccb20bba22fda5